### PR TITLE
Add dynamic metadata and related converters

### DIFF
--- a/app/(public)/[locale]/tools/[slug]/page.tsx
+++ b/app/(public)/[locale]/tools/[slug]/page.tsx
@@ -6,8 +6,6 @@ import { getConversions } from '@/utils/content';
 import { getConverter } from '@/lib/routes';
 import { LOCALES } from '@/utils/i18n';
 import { siteUrl } from '@/utils/seo';
-import { routeMeta } from '@/lib/routes';
-import { defaultDescription } from '@/utils/seo';
 import Breadcrumbs from '@/components/Breadcrumbs';
 
 type PageParams = {
@@ -26,29 +24,43 @@ export async function generateStaticParams() {
 }
 
 /* ---------- Metadata ---------- */
-export async function generateMetadata({ params }: { params: PageParams }): Promise<Metadata> {
+export async function generateMetadata(
+  { params }: { params: PageParams }
+): Promise<Metadata> {
   const { locale, slug } = params;
   const converter = getConverter(slug);
   if (!converter) return {};
 
   const isAr = locale === 'ar';
+  const [fromExt, toExt] = converter.dir.split('→');
 
-  const baseTitle = isAr ? 'تحويل ملف وورد إلى بوربوينت' : 'Convert Word to PowerPoint';
-  const variantTitle = isAr ? 'تحويل وورد إلى شرائح بوربوينت' : 'Word DOCX to PPTX converter';
+  const title = isAr
+    ? `${converter.label_ar} | Sharayeh`
+    : `${converter.label_en} | Sharayeh`;
 
-  const title = `${baseTitle} | Sharayeh`;
   const description = isAr
-    ? 'أسرع أداة مجانية لتحويل ملف وورد إلى بوربوينت بالذكاء الاصطناعي، بدون برامج، مع دعم الخطوط والصور واللغة العربية.'
-    : 'Free online tool to convert Word documents into PowerPoint slides with AI. Keep fonts, images and formatting—no software needed.';
+    ? `أداة سحابية مجانية وسهلة ${converter.label_ar} – حول ملفات ${fromExt} إلى ${toExt} في ثوانٍ مع الحفاظ على التنسيق والصور.`
+    : `Free online tool for ${converter.label_en}. Convert ${fromExt} to ${toExt} quickly and keep fonts, images and formatting intact.`;
+
+  const keywords = isAr
+    ? [
+        converter.label_ar,
+        `${fromExt} إلى ${toExt}`,
+        `تحويل ${fromExt} إلى ${toExt}`,
+        `تحويل ملف ${fromExt} إلى ${toExt}`,
+      ]
+    : [
+        converter.label_en,
+        `${fromExt} to ${toExt}`,
+        `${fromExt} to ${toExt} converter`,
+      ];
 
   const canonical = `${siteUrl}/${locale}/tools/${converter.slug_en}`;
 
   return {
     title,
     description,
-    keywords: isAr
-      ? ['تحويل ملف وورد إلى بوربوينت','تحويل وورد إلى بوربوينت','تحويل DOCX إلى PPT']
-      : ['Convert Word to PowerPoint','DOCX to PPT converter'],
+    keywords,
     alternates: {
       canonical,
       languages: {
@@ -61,7 +73,12 @@ export async function generateMetadata({ params }: { params: PageParams }): Prom
       description,
       url: canonical,
       type: 'article',
-      images: [{ url: `${siteUrl}/og/${converter.slug_en}.png`, alt: title }],
+      images: [
+        {
+          url: `${siteUrl}/og/${converter.slug_en}.png`,
+          alt: title,
+        },
+      ],
     },
     twitter: {
       card: 'summary_large_image',

--- a/components/landing/LandingTemplate.tsx
+++ b/components/landing/LandingTemplate.tsx
@@ -4,7 +4,6 @@
  * Universal landing-page layout for every converter.
  */
 
-///Users/omair/sharayeh/src/components/landing/LandingTemplate.tsx
 import StructuredData from "@/components/StructuredData";
 import Converter from "@/components/Converter";
 import FeatureSectionAr from "@/components/landing/FeatureSectionAr";
@@ -16,6 +15,7 @@ import type { Converter as ConverterRow } from "@/lib/routes";
 import { PlanBadge } from "@/components/PlanBadge";
 import { useUserPlan } from "@/context/UserContext";
 import { buildHowToSchema } from '@/components/StructuredData';
+import { getRelatedConverters } from '@/lib/routes';
 
 import LandingCopyEn   from "@/components/landing/LandingCopyEn";
 import FeatureSectionEn from "@/components/landing/FeatureSectionEn";
@@ -41,6 +41,7 @@ function dirLabel(row: ConverterRow, isAr: boolean): string {
 export default function LandingTemplate({ locale, row }: LandingTemplateProps) {
   const isAr = locale === "ar";
   const plan = useUserPlan();
+  const related = isAr ? getRelatedConverters(row.slug_en) : [];
 
   return (
     <main className="container mt-16 pt-16 min-h-screen mx-auto py-12 space-y-12">
@@ -74,14 +75,15 @@ export default function LandingTemplate({ locale, row }: LandingTemplateProps) {
   </>
 )}
 
-      {isAr && (
+      {isAr && related.length > 0 && (
         <section className="mt-12" dir="rtl">
           <h3 className="text-xl font-bold">تم البحث أيضاً عن</h3>
           <ul className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-            <li><Link href="/ar/tools/word-to-pdf">تحويل ملف وورد إلى PDF</Link></li>
-            <li><Link href="/ar/tools/pdf-to-powerpoint">تحويل PDF إلى بوربوينت</Link></li>
-            <li><Link href="/ar/tools/powerpoint-to-word">تحويل بوربوينت إلى وورد</Link></li>
-            <li><Link href="/ar/tools/ppt-ai-design">تصميم بوربوينت بالذكاء الاصطناعي</Link></li>
+            {related.map((c) => (
+              <li key={c.slug_en}>
+                <Link href={`/ar/tools/${c.slug_en}`}>{c.label_ar}</Link>
+              </li>
+            ))}
           </ul>
         </section>
       )}

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -99,6 +99,22 @@ export const getConverters = (): Converter[] =>
 export const getConverter = (slug_en: string): Converter | undefined =>
   getConverters().find((c) => c.slug_en === slug_en);
 
+export function getRelatedConverters(slug_en: string, limit = 4): Converter[] {
+  const all = getConverters();
+  const current = all.find((c) => c.slug_en === slug_en);
+  if (!current) return [];
+
+  const [fromExt, toExt] = current.dir.split('→');
+  const others = all.filter(
+    (c) =>
+      c.slug_en !== slug_en &&
+      (c.dir.includes(fromExt) || c.dir.includes(toExt))
+  );
+
+  others.sort((a, b) => Number(b.search_vol) - Number(a.search_vol));
+  return others.slice(0, limit);
+}
+
 /**
  * Build <head> metadata for a converter landing page.
  * @param locale  "en" | "ar"


### PR DESCRIPTION
## Summary
- build dynamic metadata using converter info
- provide related converter suggestions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d74370d4832e916a1f39e906c41e